### PR TITLE
chore: add lru cache to filing html

### DIFF
--- a/edgar/_filings.py
+++ b/edgar/_filings.py
@@ -1324,6 +1324,7 @@ class Filing:
         # Return all the exhibits on the filing
         return self.homepage.attachments.exhibits
 
+    @lru_cache(maxsize=4)
     def html(self) -> Optional[str]:
         """Returns the html contents of the primary document if it is html"""
         if self.document and not self.document.is_binary() and not self.document.empty:


### PR DESCRIPTION
For our use case, we fetch both the html and the text. This should prevent redundant scraping of the SEC website and speed up this process.
